### PR TITLE
Issue #228: Fix remote column missing in schema check

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -62,17 +62,6 @@ function xmldb_block_configurable_reports_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2011040106, 'block', 'configurable_reports');
     }
 
-    if ($oldversion < 2011040115) {
-
-        $table = new xmldb_table('block_configurable_reports');
-
-        $field = new xmldb_field('remote', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, null, null, '0', null);
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-        upgrade_plugin_savepoint(true, 2011040115, 'block', 'configurable_reports');
-    }
-
     if ($oldversion < 2019020600) {
         $table = new xmldb_table('block_configurable_reports');
         $field = new xmldb_field('summaryformat');
@@ -144,5 +133,16 @@ function xmldb_block_configurable_reports_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2019062001, 'block', 'configurable_reports');
     }
 
-    return true;
+    if ($oldversion < 2020110301) {
+
+        $table = new xmldb_table('block_configurable_reports');
+
+        $field = new xmldb_field('remote', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, null, null, '0', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_plugin_savepoint(true, 2020110301, 'block', 'configurable_reports');
+    }
+
+  return true;
 }

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020110300;  // Plugin version.
+$plugin->version = 2020110301;  // Plugin version.
 $plugin->requires = 2017111300; // require Moodle version (3.4).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.9.0';


### PR DESCRIPTION
Upstream issue: https://github.com/jleyva/moodle-block_configurablereports/issues/228

Version bumping the [remote](https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/upgrade.php#L65) column update as well as the plugin version in [version.php](https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/version.php#L32)