### PR TITLE
WR-426148: Run report SQL if no filter applied

### DIFF
--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -129,7 +129,10 @@ class report_sql extends report_base {
 
             $sql = $this->prepare_sql($sql);
 
-            if (isset($this->filterform) && $this->filterform->get_data() && $rs = $this->execute_query($sql)) {
+            $filterformhasdata = isset($this->filterform) && $this->filterform->get_data();
+            $nofilterform = !isset($this->filterform);
+
+            if (($filterformhasdata || $nofilterform) && $rs = $this->execute_query($sql)) {
                 foreach ($rs as $row) {
                     if (empty($finaltable)) {
                         foreach ($row as $colname => $value) {

--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -129,10 +129,10 @@ class report_sql extends report_base {
 
             $sql = $this->prepare_sql($sql);
 
-            $filterformhasdata = isset($this->filterform) && $this->filterform->get_data();
-            $nofilterform = !isset($this->filterform);
+            $filterform = isset($this->filterform);
+            $formhasdata = $filterform && $this->filterform->get_data();
 
-            if (($filterformhasdata || $nofilterform) && $rs = $this->execute_query($sql)) {
+            if (($formhasdata || !$filterform) && $rs = $this->execute_query($sql)) {
                 foreach ($rs as $row) {
                     if (empty($finaltable)) {
                         foreach ($row as $colname => $value) {


### PR DESCRIPTION
**Description:** The report is not being rendered if no filter has been applied.

---
# Default Behaviour
This is how the plugin functions prior to any changes.

**With Filter**
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/9d4e0196-b747-414b-8823-509900c608b2)

**No Filter**
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/53660d89-775f-4531-8e93-0cf60f07a118)

# Problem - Updated Behaviour
The behaviour was updated in e006f5b39d28a804fa08923b68f5bff6a5c96d79 so that the filter had to first be applied before the report result is rendered. However, if no filter is used, the results are not rendered
```php
// Default Conditional
if ($rs = $this->execute_query($sql)) {
    foreach ($rs as $row) {

// Updated Conditional
if (isset($this->filterform) && $this->filterform->get_data() && $rs = $this->execute_query($sql)) {
              foreach ($rs as $row) {
```
**With Filter**
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/24e20446-27d7-4f65-b518-ab2337c933c3)

**No Filter**
Results exist, however they are not rendered
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/fdadfb00-1a4a-42a4-b4f0-5a2b2167f531)

 # Proposed Solution
The solution combines both the default behaviour when no filter exists, and the updated behaviour when a filter exists

```php
$filterformhasdata = isset($this->filterform) && $this->filterform->get_data();
$nofilterform = !isset($this->filterform);

if (($filterformhasdata || $nofilterform) && $rs = $this->execute_query($sql)) {
    foreach ($rs as $row) {
```

**With Filter**
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/ea80a6b4-ee1c-4c1b-8d8f-e2d6792af464)

**No Filter**
![image](https://github.com/catalyst/moodle-block_configurablereports/assets/65814885/1e5f83f7-290e-4011-a229-347a8210c672)
