### PR TITLE
Fix empty export issue

### DIFF
--- a/viewreport.php
+++ b/viewreport.php
@@ -71,7 +71,9 @@ $PAGE->requires->jquery();
 $download = ($download && $format && strpos($report->export, $format.',') !== false) ? true : false;
 
 if ($download && $report->type == "sql") $reportclass->setForExport(true);
-$reportclass->check_filters_request();
+if (!$download) {
+    $reportclass->check_filters_request();
+}
 $reportclass->create_report();
 
 $action = (!empty($download)) ? 'download' : 'view';


### PR DESCRIPTION
This issue was initially introduced when letting filters be set before running reports  https://github.com/catalyst/moodle-block_configurablereports/commit/e006f5b39d28a804fa08923b68f5bff6a5c96d79 and is causing exports to empty when filters are added to a report.

At first this looked to be an issue with the newly added check for SQL reports, and adding an export check there worked for SQL reports, but upon further testing other report types were also having the same export issue, 

As such the problem seems to be a mix of both the new check and the removal of the !download condition before checking filter requests. Re-adding the !download condition while keeping the adjusted placement appears to fix the empty export issue for both SQL reports (because $this->filterform won't be set for downloads) and other reports, while not changing any functionality in the web interface.