### PR TITLE
Replace null cells with empty string

### DIFF
--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -144,7 +144,7 @@ class report_sql extends report_base {
                         if (!$this->isForExport()) {
                             $cell = format_text($cell, FORMAT_HTML, array('trusted' => true, 'noclean' => true, 'para' => false));
                         }
-                        $arrayrow[$ii] = str_replace('[[QUESTIONMARK]]', '?', $cell);
+                        $arrayrow[$ii] = str_replace('[[QUESTIONMARK]]', '?', $cell ?? '');
                     }
                     $totalrecords++;
                     $finaltable[] = $arrayrow;


### PR DESCRIPTION
### Background
In some occurrence, the records retrieved has some null values. Passing null to format_text() function parameter is deprecated as of PHP 8.1. Hence, the deprecation message can be seen in the exported file if you are using PHP 8.1. Example below for a simple mdl_user report.

Null values in user records -
![Screenshot 2024-03-21 at 4 27 02 pm](https://github.com/catalyst/moodle-block_configurablereports/assets/80394134/b0c2c15c-0339-4d0c-b0d7-d6f8b4130d92)

Deprecation message after exporting above report as a csv file
<img width="1043" alt="Screenshot 2024-03-21 at 4 28 06 pm" src="https://github.com/catalyst/moodle-block_configurablereports/assets/80394134/8a7c2dab-7c7f-4b5c-a057-db59e637b263">

### Summary of Change
Replace any null values in record as an empty string after retrieval.



