### PR TITLE
Update deprecated get_all_user_name_fields()

### DIFF
--- a/components/filters/enrolledstudents/plugin.class.php
+++ b/components/filters/enrolledstudents/plugin.class.php
@@ -22,6 +22,8 @@
  * @date: 2009
  */
 
+use core_user\fields;
+
 require_once($CFG->dirroot.'/blocks/configurable_reports/plugin.class.php');
 
 class plugin_enrolledstudents extends plugin_base{
@@ -91,10 +93,11 @@ class plugin_enrolledstudents extends plugin_base{
                 $nameformat = get_string('fullnamedisplay');
             }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(fields::get_name_fields(), $nameformat));
 
             list($usql, $params) = $remotedb->get_in_or_equal($enrolledstudentslist);
-            $enrolledstudents = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' .get_all_user_name_fields(true));
+            $enrolledstudents = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,'
+                . implode(',', fields::get_name_fields()));
 
             foreach ($enrolledstudents as $c) {
                 $enrolledstudentsoptions[$c->id] = fullname($c);

--- a/components/filters/user/plugin.class.php
+++ b/components/filters/user/plugin.class.php
@@ -22,6 +22,8 @@
  * @date: 2009
  */
 
+use core_user\fields;
+
 require_once($CFG->dirroot.'/blocks/configurable_reports/plugin.class.php');
 
 class plugin_user extends plugin_base {
@@ -82,10 +84,11 @@ class plugin_user extends plugin_base {
                 $nameformat = get_string('fullnamedisplay');
             }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(fields::get_name_fields(), $nameformat));
 
             list($usql, $params) = $remotedb->get_in_or_equal($userlist);
-            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' .get_all_user_name_fields(true));
+            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,'
+                . implode(',', fields::get_name_fields()));
 
             foreach ($users as $c) {
                 $useroptions[$c->id] = fullname($c);

--- a/components/filters/users/plugin.class.php
+++ b/components/filters/users/plugin.class.php
@@ -22,6 +22,8 @@
  * @date: 2009
  */
 
+use core_user\fields;
+
 require_once($CFG->dirroot.'/blocks/configurable_reports/plugin.class.php');
 
 class plugin_users extends plugin_base {
@@ -84,10 +86,11 @@ class plugin_users extends plugin_base {
 		        $nameformat = get_string('fullnamedisplay');
 	        }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(fields::get_name_fields(), $nameformat));
 
             list($usql, $params) = $remotedb->get_in_or_equal($userslist);
-            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' .get_all_user_name_fields(true));
+            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,'
+                . implode(',', fields::get_name_fields()));
 
             foreach ($users as $c) {
                 $usersoptions[$c->id] = fullname($c);


### PR DESCRIPTION
### Summary of Change
get_all_user_name_fields() has been deprecated since Moodle 3.11. This change is to update the deprecated function with \core_user\fields API instead.

### Testing  
To test the changes in the three files:

1.  Create a config report with the following SQL.

```
SELECT u.id
FROM prefix_user AS u
WHERE 1=1
%%FILTER_COURSEENROLLEDSTUDENTS:u.id%%

# Other filter conditions
# %%FILTER_SYSTEMUSER:u.id%%
# %%FILTER_COURSEUSER:u.id%%
```
2. Click on "Filters" 
3. Add the following filters
      a. System user (id)
      b. Course user (id)
      c. Enrolled students
4. Apply the filters on tab "View report" by adjusting the "filter conditions" attached on the SQL above (%%FILTER_), one at a time.

Expected behaviour: Filters are correctly applied.