### PR TITLE
Add embed options

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -22,6 +22,8 @@
         <FIELD NAME="lastexecutiontime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time this report took to run last time it was executed, in milliseconds."/>
         <FIELD NAME="cron" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Should we run this query on regular CRON"/>
         <FIELD NAME="remote" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="displaytotalrecords" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="displayprintbutton" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -144,5 +144,18 @@ function xmldb_block_configurable_reports_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020110301, 'block', 'configurable_reports');
     }
 
+    if ($oldversion < 2020110301.02) {
+        $table = new xmldb_table('block_configurable_reports');
+        $field = new xmldb_field('displaytotalrecords', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, null, null, '1', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        $field = new xmldb_field('displayprintbutton', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, null, null, '1', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_plugin_savepoint(true, 2020110301.02, 'block', 'configurable_reports');
+    }
+
   return true;
 }

--- a/editreport.php
+++ b/editreport.php
@@ -218,6 +218,14 @@ if ($editform->is_cancelled()) {
         $data->cron = 0;
     }
 
+    if (!isset($data->displaytotalrecords)) {
+        $data->displaytotalrecords = 0;
+    }
+
+    if (!isset($data->displayprintbutton)) {
+        $data->displayprintbutton = 0;
+    }
+
     if (empty($report)) {
         $data->ownerid = $USER->id;
         $data->courseid = $courseid;

--- a/editreport_form.php
+++ b/editreport_form.php
@@ -74,6 +74,10 @@ class report_edit_form extends moodleform {
         $mform->addHelpButton('jsordering', 'jsordering', 'block_configurable_reports');
         $mform->setDefault('jsordering', 1);
 
+        $mform->addElement('checkbox', 'displaytotalrecords', get_string('displaytotalrecords', 'block_configurable_reports'), get_string('displaytotalrecordsdescription', 'block_configurable_reports'));
+        $mform->addElement('checkbox', 'displayprintbutton', get_string('displayprintbutton', 'block_configurable_reports'), get_string('displayprintbuttondescription', 'block_configurable_reports'));
+
+
         $mform->addElement('checkbox', 'cron', get_string('cron', 'block_configurable_reports'), get_string('crondescription', 'block_configurable_reports'));
         $mform->addHelpButton('cron', 'cron', 'block_configurable_reports');
         $mform->setDefault('cron', 0);
@@ -82,6 +86,25 @@ class report_edit_form extends moodleform {
         $mform->addElement('checkbox', 'remote', get_string('remote', 'block_configurable_reports'), get_string('remotedescription', 'block_configurable_reports'));
         $mform->addHelpButton('remote', 'remote', 'block_configurable_reports');
         $mform->setDefault('remote', 0);
+
+        // Adds an embed link for easy copy/paste once the report is saved.
+        if (isset($this->_customdata['report']->id) && $this->_customdata['report']->id) {
+
+            $params = [
+                'id' => $this->_customdata['report']->id,
+                'courseid' => $this->_customdata['courseid'],
+                'embed' => true
+            ];
+            $url = new \moodle_url('/blocks/configurable_reports/viewreport.php', $params);
+
+            $mform->addElement('static', 'embedlink',
+                get_string('embedlink', 'block_configurable_reports'),
+                html_writer::tag('pre', $url, ['class' => 'mb-0']).
+                get_string('embedlinkdescription', 'block_configurable_reports')
+            );
+
+        }
+
 
         $mform->addElement('header', 'exportoptions', get_string('exportoptions', 'block_configurable_reports'));
         $options = cr_get_export_plugins();
@@ -102,8 +125,14 @@ class report_edit_form extends moodleform {
             $mform->setType('courseid', PARAM_INT);
         }
 
+        // Submit button string.
+        $submitstring = get_string('add');
+        if (!empty($this->_customdata['report']->id)) {
+            $submitstring = get_string('update');
+        }
+
         // Buttons.
-        $this->add_action_buttons(true, get_string('add'));
+        $this->add_action_buttons(true, $submitstring);
     }
 
     public function validation($data, $files) {

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -51,6 +51,7 @@ $string['configurable_reports:managesqlreports'] = "Manage SQL reports";
 $string['configurable_reports:viewreports'] = "View reports";
 
 $string['exportoptions'] = "Export options";
+$string['embedoptions'] = "Embed options";
 $string['field'] = "Field";
 
 // Report form
@@ -67,6 +68,12 @@ $string['norecordsfound'] = "No records found";
 $string['jsordering'] = 'JavaScript Ordering';
 $string['cron'] = 'Auto run daily';
 $string['crondescription'] = 'Schedule this query to run each day (At night)';
+$string['displaytotalrecords'] = 'Total Records';
+$string['displaytotalrecordsdescription'] = 'Displays the total number of results in the report';
+$string['displayprintbutton'] = 'Print Button';
+$string['displayprintbuttondescription'] = 'Displays the print button at the bottom of the report';
+$string['embedlink'] = 'Embed Link';
+$string['embedlinkdescription'] = 'You can copy this link to embed the report in an HTML block';
 $string['cron_help'] = 'Schedule this query to run each day (At night)';
 $string['remote'] = 'Run on remote db';
 $string['remotedescription'] = 'Do you want to run this query on the remote db';

--- a/report.class.php
+++ b/report.class.php
@@ -655,9 +655,11 @@ class report_base {
             echo format_text($pagecontents['header'], FORMAT_HTML);
         }
 
-        $a = new \stdClass();
-        $a->totalrecords = $this->totalrecords;
-        echo \html_writer::tag('div', get_string('totalrecords', 'block_configurable_reports', $a), array('id' => 'totalrecords'));
+        if ($this->config->displaytotalrecords) {
+            $a = new \stdClass();
+            $a->totalrecords = $this->totalrecords;
+            echo \html_writer::tag('div', get_string('totalrecords', 'block_configurable_reports', $a), array('id' => 'totalrecords'));
+        }
 
         if ($recordtpl) {
             if ($this->config->pagination) {
@@ -672,7 +674,7 @@ class report_base {
                 } else {
                     $recordtext = $recordtpl;
                 }
-                
+
                 foreach ($this->finalreport->table->head as $key => $c) {
                     $recordtext = str_ireplace("[[$c]]", $r[$key], $recordtext);
                 }
@@ -688,16 +690,20 @@ class report_base {
         }
 
         echo "</div>\n";
-        echo '<div class="centerpara"><br />';
-        echo $OUTPUT->pix_icon('print', get_string('printreport', 'block_configurable_reports'), 'block_configurable_reports');
-        echo "&nbsp;<a href=\"javascript: printDiv('printablediv')\">".get_string('printreport', 'block_configurable_reports')."</a>";
-        echo "</div>\n";
+        if ($this->config->displayprintbutton) {
+            echo '<div class="centerpara"><br />';
+            echo $OUTPUT->pix_icon('print', get_string('printreport', 'block_configurable_reports'), 'block_configurable_reports');
+            echo "&nbsp;<a href=\"javascript: printDiv('printablediv')\">".get_string('printreport', 'block_configurable_reports')."</a>";
+            echo "</div>\n";
+        }
     }
 
     public function print_report_page(\moodle_page $moodlepage) {
         global $DB, $CFG, $OUTPUT, $USER;
 
-        cr_print_js_function();
+        if ($this->config->displayprintbutton) {
+            cr_print_js_function();
+        }
         $components = cr_unserialize($this->config->components);
 
         $template = (isset($components['template']['config']) && $components['template']['config']->enabled && $components['template']['config']->record) ? $components['template']['config'] : false;
@@ -767,7 +773,10 @@ class report_base {
             // Report statistics.
             $a = new \stdClass();
             $a->totalrecords = $this->totalrecords;
-            echo \html_writer::tag('div', get_string('totalrecords', 'block_configurable_reports', $a), ['id' => 'totalrecords']);
+
+            if ($this->config->displaytotalrecords) {
+                echo \html_writer::tag('div', get_string('totalrecords', 'block_configurable_reports', $a), ['id' => 'totalrecords']);
+            }
 
             echo \html_writer::tag('div', get_string('lastexecutiontime', 'block_configurable_reports', $this->config->lastexecutiontime / 1000), array('id' => 'lastexecutiontime'));
 
@@ -786,10 +795,12 @@ class report_base {
             }
         }
 
-        echo '<div class="centerpara"><br />';
-        echo $OUTPUT->pix_icon('print', get_string('printreport', 'block_configurable_reports'), 'block_configurable_reports');
-        echo "&nbsp;<a href=\"javascript: printDiv('printablediv')\">".get_string('printreport', 'block_configurable_reports')."</a>";
-        echo "</div>\n";
+        if ($this->config->displayprintbutton) {
+            echo '<div class="centerpara"><br />';
+            echo $OUTPUT->pix_icon('print', get_string('printreport', 'block_configurable_reports'), 'block_configurable_reports');
+            echo "&nbsp;<a href=\"javascript: printDiv('printablediv')\">".get_string('printreport', 'block_configurable_reports')."</a>";
+            echo "</div>\n";
+        }
     }
 
     public function utf8_strrev($str) {

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020110301.01;  // Plugin version.
+$plugin->version = 2020110301.02;  // Plugin version.
 $plugin->requires = 2021051700.00; // require Moodle version (3.11).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v3.11.0';

--- a/viewreport.php
+++ b/viewreport.php
@@ -29,6 +29,7 @@ $id = required_param('id', PARAM_INT);
 $download = optional_param('download', false, PARAM_BOOL);
 $format = optional_param('format', '', PARAM_ALPHA);
 $courseid = optional_param('courseid', null, PARAM_INT);
+$embed = optional_param('embed', false, PARAM_BOOL);
 
 if (!$report = $DB->get_record('block_configurable_reports', ['id' => $id])) {
     print_error('reportdoesnotexists', 'block_configurable_reports');
@@ -100,9 +101,13 @@ if (!$download) {
     $PAGE->set_title($reportname);
     $PAGE->set_heading( $reportname);
     $PAGE->set_cacheable( true);
+    if ($embed) {
+        $PAGE->set_pagelayout('embedded');
+    }
     echo $OUTPUT->header();
 
-    if ($hasmanageallcap || ($hasmanageowncap && $report->ownerid == $USER->id)) {
+    $canmanage = ($hasmanageallcap || ($hasmanageowncap && $report->ownerid == $USER->id));
+    if (!$embed && $canmanage) {
         $currenttab = 'viewreport';
         include('tabs.php');
     }


### PR DESCRIPTION
This is a port of https://github.com/catalyst/moodle-block_configurablereports/pull/1 to the 311 branch

**Original features:**

- Add `embed` param to the viewreport link to skip unwanted sections by applying the page layout of 'embedded'
- Add configuration to hide the print button from the report
- Add configuration to hide the total records from the `template` report
- Add embed link in configs

**Tweaked:**

- plugin version -> `2020110301.02`
- `displaytotalrecords` check inside `print_template` function (so it applies when embedding as well)

Re-tested in Moodle 4.1, works as expected:

![image](https://github.com/catalyst/moodle-block_configurablereports/assets/17095477/ad6f49ac-cc26-4c02-8c45-2f16c710db4b)

