### PR TITLE
Fix permission issues viewing graphs

### DIFF
--- a/components/plot/bar/graph.php
+++ b/components/plot/bar/graph.php
@@ -29,12 +29,17 @@ require_login();
 
 $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
+$courseid = optional_param('courseid', null, PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
     print_error('reportdoesnotexists');
 }
 
-$courseid = $report->courseid;
+if ($courseid && $report->global) {
+    $report->courseid = $courseid;
+} else {
+    $courseid = $report->courseid;
+}
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
     print_error('No such course id');

--- a/components/plot/line/graph.php
+++ b/components/plot/line/graph.php
@@ -32,12 +32,17 @@ ini_set('display_erros', false);
 
 $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
+$courseid = optional_param('courseid', null, PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
     print_error('reportdoesnotexists');
 }
 
-$courseid = $report->courseid;
+if ($courseid && $report->global) {
+    $report->courseid = $courseid;
+} else {
+    $courseid = $report->courseid;
+}
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
     print_error('No such course id');

--- a/components/plot/pie/graph.php
+++ b/components/plot/pie/graph.php
@@ -32,12 +32,17 @@ ini_set('display_erros', false);
 
 $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
+$courseid = optional_param('courseid', null, PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
     print_error('reportdoesnotexists');
 }
 
-$courseid = $report->courseid;
+if ($courseid && $report->global) {
+    $report->courseid = $courseid;
+} else {
+    $courseid = $report->courseid;
+}
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
     print_error("No such course id");

--- a/report.class.php
+++ b/report.class.php
@@ -193,14 +193,15 @@ class report_base {
         }
     }
 
-    public function print_graphs($return = false) {
+    public function print_graphs($return = false, $courseid = 0) {
         $output = '';
         $graphs = $this->get_graphs($this->finalreport->table->data);
+        $courseidparam = $courseid ? "&courseid=$courseid" : '';
 
         if ($graphs) {
             foreach ($graphs as $g) {
                 $output .= '<div class="centerpara">';
-                $output .= ' <img src="'.$g.'" alt="'.$this->config->name.'"><br />';
+                $output .= ' <img src="' . $g . $courseidparam . '" alt="'.$this->config->name.'"><br />';
                 $output .= '</div>';
             }
         }
@@ -698,7 +699,7 @@ class report_base {
         }
     }
 
-    public function print_report_page(\moodle_page $moodlepage) {
+    public function print_report_page(\moodle_page $moodlepage, $courseid = 0) {
         global $DB, $CFG, $OUTPUT, $USER;
 
         if ($this->config->displayprintbutton) {
@@ -729,7 +730,7 @@ class report_base {
         if ($this->finalreport->table && !empty($this->finalreport->table->data[0])) {
 
             echo "<div id=\"printablediv\">\n";
-            $this->print_graphs();
+            $this->print_graphs(false, $courseid);
 
             if ($this->config->jsordering) {
                 $this->add_jsordering($moodlepage);

--- a/viewreport.php
+++ b/viewreport.php
@@ -113,7 +113,7 @@ if (!$download) {
     }
 
     // Print the report HTML.
-    $reportclass->print_report_page($PAGE);
+    $reportclass->print_report_page($PAGE, $courseid);
 
 } else {
     // Large exports are likely to take their time and memory.


### PR DESCRIPTION
**Description:** Users are experiencing issues viewing graph images when running a report that was created on the site level. This PR adds the necessary permission checks to enable users who can view the report to also view the graphs.

## Context 

A configurable report can be created at the site-level or course-level. The level the report is created in is saved to the database. Reports can be set to be available globally. Global reports can be accessed from any course. When viewing these reports, a course id parameter is passed to `viewreport.php`, i.e:

`blocks/configurable_reports/viewreport.php?id=1&courseid=9999`

The file uses the following code to decide which course id to use for checking permissions:

```php
$courseid = optional_param('courseid', null, PARAM_INT);

if (!$report = $DB->get_record('block_configurable_reports', ['id' => $id])) {
    print_error('reportdoesnotexists', 'block_configurable_reports');
}

if ($courseid && $report->global) {
    $report->courseid = $courseid;
} else {
    $courseid = $report->courseid;
}

if (!$course = $DB->get_record('course', ['id' => $courseid])) {
    print_error('No such course id');
}

// Force user login in course (SITE or Course).
if ($course->id == SITEID) {
    require_login();
    $context = context_system::instance();
} else {
    require_login($course);
    $context = context_course::instance($course->id);
}

require_once($CFG->dirroot.'/blocks/configurable_reports/report.class.php');
require_once($CFG->dirroot.'/blocks/configurable_reports/reports/'.$report->type.'/report.class.php');

$reportclassname = 'report_'.$report->type;
$reportclass = new $reportclassname($report);

if (!$reportclass->check_permissions($USER->id, $context)) {
    print_error('badpermissions', 'block_configurable_reports');
}
```

So it checks for the existence of the `courseid` parameter. If it exists (and it is not the site-level courseid `1`, it creates the `$context` variable on the course level. This context is passed to the `check_permissions` function. 

Permissions are set on the report:

![image](https://github.com/user-attachments/assets/a4dc763f-e5af-4154-b861-c8437fee969d)

## Problem
This becomes an issue when viewing graphs of a report. Compared to the above code in `viewreport.php`, the `courseid` is not passed to the respective graph file. It only uses the courseid that the report was created in. So when viewing a global report that was created on the site level, the user must have permissions on the site level:

`blocks/configurable_reports/components/plot/pie/graph.php`
```php
$id = required_param('id', PARAM_ALPHANUM);
$reportid = required_param('reportid', PARAM_INT);

if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
    print_error('reportdoesnotexists');
}

$courseid = $report->courseid;

if (!$course = $DB->get_record('course', array('id' => $courseid))) {
    print_error("No such course id");
}

// Force user login in course (SITE or Course).
if ($course->id == SITEID) {
    require_login();
    $context = context_system::instance();
} else {
    require_login($course->id);
    $context = context_course::instance($course->id);
}
```

## Solution
We pass the `courseid` to the graph files and apply the same checks there as we do in `viewreport.php`.