### PR TITLE
Bug fixes

### DIFF
--- a/components/plot/pie/plugin.class.php
+++ b/components/plot/pie/plugin.class.php
@@ -128,19 +128,21 @@ class plugin_pie extends plugin_base {
         $i = 0;
         $unmappedindex = 0;
         $unmappedcolorcount = count($unmappedcolors);
-        foreach ($series[0] as $index => $serie) {
-            $serie = strip_tags($serie);
-            $serie0sorted[] = $serie;
-            $serie1sorted[] = $series[1][$index];
-            if (in_array($serie, $mappedcolorkeys)) {
-                $colors[$i] = $this->parse_color($mappedcolors[$serie]);
-            } else if ($unmappedindex < $unmappedcolorcount) {
-                $colors[$i] = $this->parse_color($unmappedcolors[$unmappedindex]);
-                $unmappedindex++;
-            } else {
-                $colors[$i] = '';
+        if (isset($series[0])) {
+            foreach ($series[0] as $index => $serie) {
+                $serie = strip_tags($serie);
+                $serie0sorted[] = $serie;
+                $serie1sorted[] = $series[1][$index];
+                if (in_array($serie, $mappedcolorkeys)) {
+                    $colors[$i] = $this->parse_color($mappedcolors[$serie]);
+                } else if ($unmappedindex < $unmappedcolorcount) {
+                    $colors[$i] = $this->parse_color($unmappedcolors[$unmappedindex]);
+                    $unmappedindex++;
+                } else {
+                    $colors[$i] = '';
+                }
+                $i++;
             }
-            $i++;
         }
 
         $serie0 = base64_encode(strip_tags(implode(',', $serie0sorted)));

--- a/lib/pChart/pData.class.php
+++ b/lib/pChart/pData.class.php
@@ -123,7 +123,7 @@ class pData {
             }
         }
 
-        if (count($Value) == 1) {
+        if (!is_array($Value)) {
             $this->Data[$ID][$Serie] = $Value;
             if ($Description != "") {
                 $this->Data[$ID]["Name"] = $Description;

--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -185,6 +185,12 @@ class report_sql extends report_base {
             $filterform = isset($this->filterform);
             $formhasdata = $filterform && $this->filterform->get_data();
 
+            $page = optional_param('page', 0, PARAM_INT);
+            if ($page) {
+                // Pagination is being used, we assume the filter data is included.
+                $formhasdata = true;
+            }
+
             if (($formhasdata || !$filterform) && $rs = $this->execute_query($sql)) {
                 foreach ($rs as $row) {
                     if (empty($finaltable)) {


### PR DESCRIPTION
This fixes the following bugs:
- Coding error when chart only has one value
    - This is due to the value being converted from an array into a single value and count not working on it
-  PHP warning when the filters haven't been applied yet because `$series[0]` is not set
- Pagination not working with custom SQL reports
    - This is due to the form not technically being 'submitted' so the form was returning that there is no data
    - I opted to checking that the `page` param has been set, implying the rest of the data exists and the user is using the pagination