### PR TITLE
fix: only include role if roles are selected for activity stats

### DIFF
--- a/components/columns/coursestats/plugin.class.php
+++ b/components/columns/coursestats/plugin.class.php
@@ -98,12 +98,12 @@ class plugin_coursestats extends plugin_base {
             case 'activityview':
                 $total = 'SUM(stat1)';
                 $stattype = 'activity';
-                $extrasql = " AND roleid IN (" . implode(',', $numericroles ). ")";
+                $extrasql = !empty($numericroles) ? " AND roleid IN (" . implode(',', $numericroles). ")" : '';
                 break;
             case 'activitypost':
                 $total = 'SUM(stat2)';
                 $stattype = 'activity';
-                $extrasql = " AND roleid IN (" . implode(',', $numericroles) . ")";
+                $extrasql = !empty($numericroles) ? " AND roleid IN (" . implode(',', $numericroles). ")" : '';
                 break;
             case 'activeenrolments':
                 $total = 'stat2';


### PR DESCRIPTION
Currently if you don't select any roles for the course activity stats (activity view and activity post) the SQL will contain `roleid IN ()` which isn't valid. Solution is to only include the `roleid` where clause if roles have been selected for the column.