### PR TITLE
feat: add course selection for gloabl SQL report fields

### DIFF
--- a/components/calcs/average/plugin.class.php
+++ b/components/calcs/average/plugin.class.php
@@ -79,8 +79,9 @@ class plugin_average extends plugin_base {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/calcs/component.class.php
+++ b/components/calcs/component.class.php
@@ -90,8 +90,9 @@ class component_calcs extends component_base {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/calcs/max/plugin.class.php
+++ b/components/calcs/max/plugin.class.php
@@ -81,8 +81,9 @@ class plugin_max extends plugin_base {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/calcs/min/plugin.class.php
+++ b/components/calcs/min/plugin.class.php
@@ -80,8 +80,9 @@ class plugin_min extends plugin_base {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/calcs/percent/plugin.class.php
+++ b/components/calcs/percent/plugin.class.php
@@ -80,8 +80,9 @@ class plugin_percent extends plugin_base {
             $config = $components['customsql']['config'] ?? new stdclass;
 
             if (isset($config->querysql)) {
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/calcs/sum/plugin.class.php
+++ b/components/calcs/sum/plugin.class.php
@@ -78,8 +78,9 @@ class plugin_sum extends plugin_base {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/customsql/form.php
+++ b/components/customsql/form.php
@@ -50,6 +50,12 @@ class customsql_form extends moodleform {
         $mform->addRule('querysql', get_string('required'), 'required', null, 'client');
         $mform->setType('querysql', PARAM_RAW);
 
+        if (isset($this->_customdata['report']->global) && $this->_customdata['report']->global) {
+            // Add a course field so we can switch context to fetch fields from a valid course if required.
+            $mform->addElement('course', 'fieldscourseid', get_string('course'));
+            $mform->addElement('static', 'fieldscourseidhelp', '', nl2br(get_string('fieldscourseidhelp_help', 'block_configurable_reports')));
+        }
+
         $mform->addElement('hidden', 'courseid', $COURSE->id);
         $mform->setType('courseid', PARAM_INT);
 

--- a/components/plot/bar/form.php
+++ b/components/plot/bar/form.php
@@ -72,8 +72,9 @@ class bar_form extends moodleform {
             $config = $components['customsql']['config'] ?? new stdclass;
 
             if (isset($config->querysql)) {
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/plot/line/form.php
+++ b/components/plot/line/form.php
@@ -69,8 +69,9 @@ class line_form extends moodleform {
             $config = (isset($components['customsql']['config'])) ? $components['customsql']['config'] : new stdclass;
 
             if (isset($config->querysql)) {
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 1;

--- a/components/plot/pie/form.php
+++ b/components/plot/pie/form.php
@@ -72,8 +72,9 @@ class pie_form extends moodleform {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/components/template/form.php
+++ b/components/template/form.php
@@ -69,8 +69,9 @@ class template_form extends moodleform {
 
             if (isset($config->querysql)) {
 
+                $courseid = isset($config->fieldscourseid) && !empty($config->fieldscourseid) ? $config->fieldscourseid : 0;
                 $sql = $config->querysql;
-                $sql = $reportclass->prepare_sql($sql);
+                $sql = $reportclass->prepare_sql($sql, $courseid);
                 if ($rs = $reportclass->execute_query($sql)) {
                     foreach ($rs as $row) {
                         $i = 0;

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -574,6 +574,8 @@ $string['generalcolorpaletteheader'] = 'General color palette';
 $string['generalcolorpalette'] = 'Unmapped Palette';
 $string['generalcolorpalette_help'] = 'Hexadecimal color codes for general use in the pie chart. Codes should be separated
 by new lines in the order you wish them to be used in the pie chart.';
+$string['fieldscourseidhelp_help'] = 'Some configuration pages require the report to return results to extract availiable course fields.
+If your report requires a different course to return results, please select a course that will return them to populate the available course fields.';
 
 $string['checksql_execution'] = 'Block Configurable Reports SQL execution';
 $string['checksql_execution_ok'] = 'SQL execution is disabled.';

--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -80,8 +80,18 @@ class report_sql extends report_base {
      * @param string $sql
      * @return array|string|string[]
      */
-    public function prepare_sql(string $sql) {
-        global $USER, $CFG, $COURSE;
+    public function prepare_sql(string $sql, int $forcedcourseid = 0) {
+        global $USER, $CFG, $COURSE, $DB;
+
+        $course = $COURSE;
+
+        // If a forced course id has been passed, use the forced course instead of the current course.
+        if ($forcedcourseid) {
+            $forcedcourse = $DB->get_record('course', ['id' => $forcedcourseid]);
+            if ($forcedcourse) {
+                $course = $forcedcourse;
+            }
+        }
 
         // Enable debug mode from SQL query.
         $this->config->debug = strpos($sql, '%%DEBUG%%') !== false;
@@ -103,7 +113,7 @@ class report_sql extends report_base {
             '%%ENDTIME%%',
             '%%WWWROOT%%',
         ],
-            [$USER->id, $COURSE->id, $COURSE->category, '0', '2145938400', $CFG->wwwroot],
+            [$USER->id, $course->id, $course->category, '0', '2145938400', $CFG->wwwroot],
             $sql);
         $sql = preg_replace('/%{2}[^%]+%{2}/i', '', $sql);
 

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024051300;
+$plugin->version = 2024051301;
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0';


### PR DESCRIPTION
Issue:
For custom SQL reports the field options for things like calculations and graphs are derived from executing the SQL and looking at the fields returned. Sometimes when you have a global report attached to the site course using `%%COURSEID%%` there might not be any results, leading to no options shown for course fields.

Fix:
This adds a new course field to the custom SQL form and config that can be used for the purposes of fetching available course fields.