### PR TITLE
Fix failing unit tests fatal error

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -60,7 +60,7 @@ class provider implements
      * @param collection $collection The initialised collection to add items to.
      * @return collection A listing of user data stored through this system.
      */
-    public static function get_metadata(collection $collection) {
+    public static function get_metadata(collection $collection): collection {
 
         $collection->add_database_table('block_configurable_reports', [
             'courseid' => 'privacy:metadata:block_configurable_reports:courseid',
@@ -83,7 +83,7 @@ class provider implements
      * @param int $userid The user to search.
      * @return  contextlist $contextlist The contextlist containing the list of contexts used in this plugin.
      */
-    public static function get_contexts_for_userid($userid) {
+    public static function get_contexts_for_userid($userid): contextlist {
         $contextlist = new contextlist();
 
         // Find the reports created by the userid.


### PR DESCRIPTION
fix unit test error:

```
Fatal error: Declaration of block_configurable_reports\privacy\provider::get_metadata(core_privacy\local\metadata\collection $collection) must be compatible with core_privacy\local\metadata\provider::get_metadata(core_privacy\local\metadata\collection $collection): core_privacy\local\metadata\collection in /var/www/monash-45/blocks/configurable_reports/classes/privacy/provider.php on line 63
```