### PR TITLE
add dynamic field sql report web service functions

### DIFF
--- a/DYNAMIC_SQL.md
+++ b/DYNAMIC_SQL.md
@@ -1,0 +1,78 @@
+# Dynamic SQL report parameters
+
+Configurable Reports web services can apply optional, bound values to SQL report queries. This lets a client retrieve a report's available parameters, submit values, and receive filtered data without interpolating user input into SQL.
+
+## Web services
+
+- `block_configurable_reports_get_reports` returns reports the current user is permitted to access. Each report includes its `id`, `name`, `summary`, `courseid`, `global` flag, type, and any dynamic parameters.
+- `block_configurable_reports_get_report_data` accepts a report ID, an optional course ID, and optional parameter values. It returns the report data as a JSON string.
+
+Reports with invalid dynamic parameters are omitted from `get_reports` and returned in its `warnings` collection. Unsupported report types or missing report classes are also returned as warnings.
+
+## Placeholder syntax
+
+Add placeholders to the SQL query where optional conditions should be appended:
+
+```text
+%%DYNAMIC_NAME:field:operator%%
+```
+
+`NAME` identifies the submitted parameter, `field` is the SQL field to filter, and `operator` is optional. If omitted, the operator defaults to `~`. Operators are case-insensitive.
+
+For example:
+
+```sql
+SELECT u.id, u.username, u.firstname, u.lastname, u.email
+FROM prefix_user u
+WHERE u.deleted = 0
+%%DYNAMIC_USERNAME:u.username:~%%
+%%DYNAMIC_USER_ID:u.id:=%%
+```
+
+`NAME` is case-insensitive and may contain letters, numbers, underscores, and hyphens. Each name may appear only once in a report, regardless of case. `field` must be either a field name such as `id` or a single table-alias-qualified field such as `u.id`.
+
+## Supported operators
+
+| Operator | Meaning | Submitted value example | Generated condition |
+| --- | --- | --- | --- |
+| `~` | Contains match (default) | `smith` | `AND u.username LIKE '%smith%'` |
+| `=` | Exact match | `42` | `AND u.id = 42` |
+| `<` | Less than | `100` | `AND u.id < 100` |
+| `>` | Greater than | `100` | `AND u.id > 100` |
+| `<=` | Less than or equal to | `100` | `AND u.id <= 100` |
+| `>=` | Greater than or equal to | `100` | `AND u.id >= 100` |
+| `in` | Match any value in a list | `1,2,3` | `AND u.id IN (1, 2, 3)` |
+
+The generated SQL shown above is illustrative. Values are always passed to Moodle through bound DML parameters, rather than embedded in the SQL text.
+
+For `~`, `%` and `_` in the submitted value are treated as literal characters. For `in`, separate values with commas. Whitespace and surrounding single or double quotes are removed from each value; use `\,` for a literal comma within one value.
+
+## Calling a report
+
+First call `block_configurable_reports_get_reports` to discover the report ID and supported parameters. Then submit values to `block_configurable_reports_get_report_data`:
+
+```json
+{
+  "reportid": 123,
+  "courseid": 1,
+  "parameters": [
+    {
+      "name": "USERNAME",
+      "value": "smith"
+    },
+    {
+      "name": "USER_ID",
+      "value": "42"
+    }
+  ]
+}
+```
+
+Parameter names are case-insensitive. A supplied name must contain only letters, numbers, underscores, and hyphens, and it may be supplied only once. Omitting a parameter, or supplying an empty value, removes its placeholder without adding a filter.
+
+## Validation and safety
+
+- Duplicate placeholder names prevent the report from being saved and are reported by `get_reports` as a warning for existing reports.
+- A placeholder with unsupported syntax or an unsupported operator is rejected when the report is run; it is not silently executed as SQL.
+- Only the field and operator written in the report SQL are used. Submitted values are bound query parameters.
+- Dynamic conditions are appended with `AND`. Structure the surrounding SQL accordingly; placeholders do not add `WHERE`, `OR`, joins, ordering, or arbitrary SQL fragments.

--- a/classes/external.php
+++ b/classes/external.php
@@ -77,7 +77,7 @@ class external extends external_api {
      * @param array $parameters dynamic report parameters
      * @return array An array with a 'data' JSON string and a 'warnings' string
      */
-    public static function get_report_data($reportid, int $courseid = 1, array $parameters = []): array {
+    public static function get_report_data(int $reportid, int $courseid = 1, array $parameters = []): array {
         global $CFG, $DB, $USER;
 
         $params = self::validate_parameters(
@@ -105,7 +105,10 @@ class external extends external_api {
             $reportclassname = 'report_' . $report->type;
             $reportclass = new $reportclassname($report);
             if (!$reportclass->check_permissions($USER->id, $context)) {
-                $warnings = get_string('badpermissions', 'block_configurable_reports');
+                return [
+                    'data' => json_encode($json, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT),
+                    'warnings' => get_string('badpermissions', 'block_configurable_reports'),
+                ];
             }
 
             if ($report->type === 'sql' && self::has_dynamic_sql_placeholders($report)) {
@@ -148,11 +151,11 @@ class external extends external_api {
 
 
     /**
-     * get_dynamic_reports parameters.
+     * get_reports parameters.
      *
      * @return external_function_parameters
      */
-    public static function get_dynamic_reports_parameters(): external_function_parameters {
+    public static function get_reports_parameters(): external_function_parameters {
         return new external_function_parameters(
             [
                 'courseid' => new external_value(PARAM_INT, 'The course id', VALUE_DEFAULT, SITEID),
@@ -161,16 +164,16 @@ class external extends external_api {
     }
 
     /**
-     * Returns SQL reports available to the current user and their dynamic parameters.
+     * Returns reports available to the current user and their dynamic parameters.
      *
      * @param int $courseid course id
      * @return array
      */
-    public static function get_dynamic_reports(int $courseid = SITEID): array {
+    public static function get_reports(int $courseid = SITEID): array {
         global $CFG, $DB, $USER;
 
         $params = self::validate_parameters(
-            self::get_dynamic_reports_parameters(),
+            self::get_reports_parameters(),
             ['courseid' => $courseid]
         );
         $courseid = $params['courseid'];
@@ -186,16 +189,22 @@ class external extends external_api {
         require_once($CFG->dirroot . '/blocks/configurable_reports/locallib.php');
         require_once($CFG->dirroot . '/blocks/configurable_reports/report.class.php');
 
-        $reports = $DB->get_records(
-            'block_configurable_reports',
-            ['type' => 'sql'],
-            'name ASC'
-        );
+        $reports = $DB->get_records('block_configurable_reports', null, 'name ASC');
 
         $result = [];
         $warnings = [];
         foreach ($reports as $report) {
             $reportclassfile = $CFG->dirroot . '/blocks/configurable_reports/reports/' . $report->type . '/report.class.php';
+            if (!file_exists($reportclassfile)) {
+                $warnings[] = [
+                    'item' => 'report',
+                    'itemid' => $report->id,
+                    'warningcode' => 'missingreportclassfile',
+                    'message' => get_string('missingreportclassfile', 'block_configurable_reports'),
+                ];
+                continue;
+            }
+
             require_once($reportclassfile);
             $reportclassname = 'report_' . $report->type;
             if (!class_exists($reportclassname)) {
@@ -213,9 +222,22 @@ class external extends external_api {
                 continue;
             }
 
-            $components = cr_unserialize($report->components);
-            if (empty($components['customsql']['config']->querysql)) {
-                continue;
+            $parameters = [];
+            if ($report->type === 'sql') {
+                $components = cr_unserialize($report->components);
+                if (!empty($components['customsql']['config']->querysql)) {
+                    try {
+                        $parameters = dynamic_sql::extract_parameters($components['customsql']['config']->querysql);
+                    } catch (moodle_exception $e) {
+                        $warnings[] = [
+                            'item' => 'report',
+                            'itemid' => $report->id,
+                            'warningcode' => 'invaliddynamicparameters',
+                            'message' => get_string('invaliddynamicparameters', 'block_configurable_reports'),
+                        ];
+                        continue;
+                    }
+                }
             }
 
             $result[] = [
@@ -223,8 +245,9 @@ class external extends external_api {
                 'name' => $report->name,
                 'summary' => $report->summary ?? '',
                 'courseid' => $report->courseid ?? 0,
+                'global' => !empty($report->global),
                 'type' => $report->type,
-                'parameters' => dynamic_sql::extract_parameters($components['customsql']['config']->querysql),
+                'parameters' => $parameters,
             ];
         }
 
@@ -235,11 +258,11 @@ class external extends external_api {
     }
 
     /**
-     * get_dynamic_reports return.
+     * get_reports return.
      *
      * @return external_single_structure
      */
-    public static function get_dynamic_reports_returns(): external_single_structure {
+    public static function get_reports_returns(): external_single_structure {
         return new external_single_structure(
             [
                 'reports' => new external_multiple_structure(
@@ -248,6 +271,7 @@ class external extends external_api {
                         'name' => new external_value(PARAM_TEXT, 'Report name'),
                         'summary' => new external_value(PARAM_RAW, 'Report summary'),
                         'courseid' => new external_value(PARAM_INT, 'Report course ID'),
+                        'global' => new external_value(PARAM_BOOL, 'Whether the report is global'),
                         'type' => new external_value(PARAM_ALPHANUMEXT, 'Report type'),
                         'parameters' => new external_multiple_structure(
                             new external_single_structure([

--- a/classes/external.php
+++ b/classes/external.php
@@ -156,35 +156,18 @@ class external extends external_api {
      * @return external_function_parameters
      */
     public static function get_reports_parameters(): external_function_parameters {
-        return new external_function_parameters(
-            [
-                'courseid' => new external_value(PARAM_INT, 'The course id', VALUE_DEFAULT, SITEID),
-            ]
-        );
+        return new external_function_parameters([]);
     }
 
     /**
      * Returns reports available to the current user and their dynamic parameters.
      *
-     * @param int $courseid course id
      * @return array
      */
-    public static function get_reports(int $courseid = SITEID): array {
+    public static function get_reports(): array {
         global $CFG, $DB, $USER;
 
-        $params = self::validate_parameters(
-            self::get_reports_parameters(),
-            ['courseid' => $courseid]
-        );
-        $courseid = $params['courseid'];
-
-        if ($courseid === SITEID) {
-            $context = context_system::instance();
-        } else {
-            $context = context_course::instance($courseid);
-        }
-
-        self::validate_context($context);
+        self::validate_parameters(self::get_reports_parameters(), []);
 
         require_once($CFG->dirroot . '/blocks/configurable_reports/locallib.php');
         require_once($CFG->dirroot . '/blocks/configurable_reports/report.class.php');
@@ -200,6 +183,19 @@ class external extends external_api {
         $result = [];
         $warnings = [];
         foreach ($reports as $report) {
+            $reportcontext = $report->global
+                ? context_system::instance()
+                : context_course::instance($report->courseid, IGNORE_MISSING);
+            if (!$reportcontext) {
+                continue;
+            }
+
+            try {
+                self::validate_context($reportcontext);
+            } catch (moodle_exception $e) {
+                continue;
+            }
+
             $reportclassfile = $CFG->dirroot . '/blocks/configurable_reports/reports/' . $report->type . '/report.class.php';
             if (!file_exists($reportclassfile)) {
                 $warnings[] = [
@@ -224,13 +220,6 @@ class external extends external_api {
             }
 
             $reportclass = new $reportclassname($report);
-            $reportcontext = $report->global
-                ? context_system::instance()
-                : context_course::instance($report->courseid, IGNORE_MISSING);
-            if (!$reportcontext) {
-                continue;
-            }
-
             if (!$reportclass->check_permissions($USER->id, $reportcontext)) {
                 continue;
             }

--- a/classes/external.php
+++ b/classes/external.php
@@ -149,7 +149,6 @@ class external extends external_api {
         );
     }
 
-
     /**
      * get_reports parameters.
      *

--- a/classes/external.php
+++ b/classes/external.php
@@ -32,8 +32,12 @@ use context_course;
 use context_system;
 use external_api;
 use external_function_parameters;
+use external_multiple_structure;
 use external_single_structure;
 use external_value;
+use block_configurable_reports\local\dynamic_report;
+use block_configurable_reports\local\dynamic_sql;
+use moodle_exception;
 
 /**
  * This is the external API for this component.
@@ -52,6 +56,15 @@ class external extends external_api {
             [
                 'reportid' => new external_value(PARAM_INT, 'The report id', VALUE_REQUIRED),
                 'courseid' => new external_value(PARAM_INT, 'The course id', VALUE_DEFAULT, 1),
+                'parameters' => new external_multiple_structure(
+                    new external_single_structure([
+                        'name' => new external_value(PARAM_ALPHANUMEXT, 'Dynamic parameter name'),
+                        'value' => new external_value(PARAM_RAW, 'Dynamic parameter value'),
+                    ]),
+                    'Dynamic report parameters',
+                    VALUE_DEFAULT,
+                    []
+                ),
             ]
         );
     }
@@ -61,14 +74,15 @@ class external extends external_api {
      *
      * @param int $reportid the report id
      * @param int $courseid course id (default to site)
+     * @param array $parameters dynamic report parameters
      * @return array An array with a 'data' JSON string and a 'warnings' string
      */
-    public static function get_report_data($reportid, int $courseid = 1): array {
+    public static function get_report_data($reportid, int $courseid = 1, array $parameters = []): array {
         global $CFG, $DB, $USER;
 
         $params = self::validate_parameters(
             self::get_report_data_parameters(),
-            ['reportid' => $reportid, 'courseid' => $courseid]
+            ['reportid' => $reportid, 'courseid' => $courseid, 'parameters' => $parameters]
         );
 
         if ($courseid === SITEID) {
@@ -92,6 +106,12 @@ class external extends external_api {
             $reportclass = new $reportclassname($report);
             if (!$reportclass->check_permissions($USER->id, $context)) {
                 $warnings = get_string('badpermissions', 'block_configurable_reports');
+            }
+
+            if ($report->type === 'sql' && self::has_dynamic_sql_placeholders($report)) {
+                [$report, $queryparams] = self::apply_dynamic_sql_to_report($report, $parameters);
+                $reportclass = new dynamic_report($report);
+                $reportclass->set_query_parameters($queryparams);
             }
 
             $reportclass->create_report();
@@ -124,5 +144,171 @@ class external extends external_api {
                 'warnings' => new external_value(PARAM_TEXT, 'Warning message'),
             ]
         );
+    }
+
+
+    /**
+     * get_dynamic_reports parameters.
+     *
+     * @return external_function_parameters
+     */
+    public static function get_dynamic_reports_parameters(): external_function_parameters {
+        return new external_function_parameters(
+            [
+                'courseid' => new external_value(PARAM_INT, 'The course id', VALUE_DEFAULT, SITEID),
+            ]
+        );
+    }
+
+    /**
+     * Returns SQL reports available to the current user and their dynamic parameters.
+     *
+     * @param int $courseid course id
+     * @return array
+     */
+    public static function get_dynamic_reports(int $courseid = SITEID): array {
+        global $CFG, $DB, $USER;
+
+        $params = self::validate_parameters(
+            self::get_dynamic_reports_parameters(),
+            ['courseid' => $courseid]
+        );
+        $courseid = $params['courseid'];
+
+        if ($courseid === SITEID) {
+            $context = context_system::instance();
+        } else {
+            $context = context_course::instance($courseid);
+        }
+
+        self::validate_context($context);
+
+        require_once($CFG->dirroot . '/blocks/configurable_reports/locallib.php');
+        require_once($CFG->dirroot . '/blocks/configurable_reports/report.class.php');
+
+        $reports = $DB->get_records(
+            'block_configurable_reports',
+            ['type' => 'sql'],
+            'name ASC'
+        );
+
+        $result = [];
+        $warnings = [];
+        foreach ($reports as $report) {
+            $reportclassfile = $CFG->dirroot . '/blocks/configurable_reports/reports/' . $report->type . '/report.class.php';
+            require_once($reportclassfile);
+            $reportclassname = 'report_' . $report->type;
+            if (!class_exists($reportclassname)) {
+                $warnings[] = [
+                    'item' => 'report',
+                    'itemid' => $report->id,
+                    'warningcode' => 'missingreportclass',
+                    'message' => get_string('missingreportclass', 'block_configurable_reports'),
+                ];
+                continue;
+            }
+
+            $reportclass = new $reportclassname($report);
+            if (!$reportclass->check_permissions($USER->id, $context)) {
+                continue;
+            }
+
+            $components = cr_unserialize($report->components);
+            if (empty($components['customsql']['config']->querysql)) {
+                continue;
+            }
+
+            $result[] = [
+                'id' => $report->id,
+                'name' => $report->name,
+                'summary' => $report->summary ?? '',
+                'courseid' => $report->courseid ?? 0,
+                'type' => $report->type,
+                'parameters' => dynamic_sql::extract_parameters($components['customsql']['config']->querysql),
+            ];
+        }
+
+        return [
+            'reports' => $result,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * get_dynamic_reports return.
+     *
+     * @return external_single_structure
+     */
+    public static function get_dynamic_reports_returns(): external_single_structure {
+        return new external_single_structure(
+            [
+                'reports' => new external_multiple_structure(
+                    new external_single_structure([
+                        'id' => new external_value(PARAM_INT, 'Report ID'),
+                        'name' => new external_value(PARAM_TEXT, 'Report name'),
+                        'summary' => new external_value(PARAM_RAW, 'Report summary'),
+                        'courseid' => new external_value(PARAM_INT, 'Report course ID'),
+                        'type' => new external_value(PARAM_ALPHANUMEXT, 'Report type'),
+                        'parameters' => new external_multiple_structure(
+                            new external_single_structure([
+                                'name' => new external_value(PARAM_ALPHANUMEXT, 'Dynamic parameter name'),
+                                'field' => new external_value(PARAM_TEXT, 'SQL field used by the parameter'),
+                                'operator' => new external_value(PARAM_RAW, 'SQL operator'),
+                                'placeholder' => new external_value(PARAM_RAW, 'Full SQL placeholder'),
+                                'required' => new external_value(PARAM_BOOL, 'Whether the parameter is required'),
+                            ])
+                        ),
+                    ])
+                ),
+                'warnings' => new external_multiple_structure(
+                    new external_single_structure([
+                        'item' => new external_value(PARAM_TEXT, 'Warning item type'),
+                        'itemid' => new external_value(PARAM_INT, 'Warning item ID'),
+                        'warningcode' => new external_value(PARAM_TEXT, 'Warning code'),
+                        'message' => new external_value(PARAM_TEXT, 'Warning message'),
+                    ])
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Applies dynamic SQL parameters to the report object in memory.
+     *
+     * This does not save the modified SQL back to the database.
+     *
+     * @param object $report Configurable Reports DB record.
+     * @param array $parameters Dynamic parameters.
+     * @return array Modified in-memory report object and DML query parameters.
+     */
+    private static function apply_dynamic_sql_to_report(object $report, array $parameters): array {
+        $components = cr_unserialize($report->components);
+
+        if (empty($components['customsql']['config']->querysql)) {
+            throw new moodle_exception('missingcustomsql', 'block_configurable_reports');
+        }
+
+        $sql = $components['customsql']['config']->querysql;
+        [$sql, $queryparams] = dynamic_sql::apply_parameters($sql, $parameters);
+
+        $components['customsql']['config']->querysql = $sql;
+        $report->components = cr_serialize($components);
+
+        return [$report, $queryparams];
+    }
+
+    /**
+     * Checks whether the SQL report contains dynamic placeholders.
+     *
+     * @param object $report Configurable Reports DB record.
+     * @return bool
+     */
+    private static function has_dynamic_sql_placeholders(object $report): bool {
+        $components = cr_unserialize($report->components);
+        if (empty($components['customsql']['config']->querysql)) {
+            return false;
+        }
+
+        return stripos($components['customsql']['config']->querysql, '%%DYNAMIC_') !== false;
     }
 }

--- a/classes/external.php
+++ b/classes/external.php
@@ -218,7 +218,8 @@ class external extends external_api {
             }
 
             $reportclass = new $reportclassname($report);
-            if (!$reportclass->check_permissions($USER->id, $context)) {
+            $reportcontext = $report->global ? context_system::instance() : context_course::instance($report->courseid);
+            if (!$reportclass->check_permissions($USER->id, $reportcontext)) {
                 continue;
             }
 
@@ -304,6 +305,8 @@ class external extends external_api {
      * @param object $report Configurable Reports DB record.
      * @param array $parameters Dynamic parameters.
      * @return array Modified in-memory report object and DML query parameters.
+     * @throws \invalid_parameter_exception If a submitted parameter is invalid or duplicated.
+     * @throws moodle_exception If the report has no custom SQL or contains unresolved dynamic placeholders.
      */
     private static function apply_dynamic_sql_to_report(object $report, array $parameters): array {
         $components = cr_unserialize($report->components);

--- a/classes/external.php
+++ b/classes/external.php
@@ -189,7 +189,13 @@ class external extends external_api {
         require_once($CFG->dirroot . '/blocks/configurable_reports/locallib.php');
         require_once($CFG->dirroot . '/blocks/configurable_reports/report.class.php');
 
-        $reports = $DB->get_records('block_configurable_reports', null, 'name ASC');
+        $reports = $DB->get_records_sql(
+            "SELECT r.*
+               FROM {block_configurable_reports} r
+          LEFT JOIN {course} c ON c.id = r.courseid
+              WHERE r.global = 1 OR c.id IS NOT NULL
+           ORDER BY r.name ASC"
+        );
 
         $result = [];
         $warnings = [];
@@ -218,7 +224,13 @@ class external extends external_api {
             }
 
             $reportclass = new $reportclassname($report);
-            $reportcontext = $report->global ? context_system::instance() : context_course::instance($report->courseid);
+            $reportcontext = $report->global
+                ? context_system::instance()
+                : context_course::instance($report->courseid, IGNORE_MISSING);
+            if (!$reportcontext) {
+                continue;
+            }
+
             if (!$reportclass->check_permissions($USER->id, $reportcontext)) {
                 continue;
             }

--- a/classes/local/dynamic_report.php
+++ b/classes/local/dynamic_report.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_configurable_reports\local;
+
+/**
+ * Runs a Configurable Reports SQL report with bound dynamic parameters.
+ *
+ * @package    block_configurable_reports
+ * @copyright  2026 Frank Saikali <fsjk85@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class dynamic_report extends \report_sql {
+    /** @var array DML query parameters. */
+    private array $queryparams = [];
+
+    /**
+     * Sets the DML parameters for the next report execution.
+     *
+     * @param array $queryparams DML query parameters.
+     */
+    public function set_query_parameters(array $queryparams): void {
+        $this->queryparams = $queryparams;
+    }
+
+    /**
+     * Executes the report query with its dynamic DML parameters.
+     *
+     * @param string $sql SQL query.
+     * @return mixed
+     */
+    public function execute_query($sql) {
+        global $CFG, $DB, $remotedb;
+
+        $sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
+        $reportlimit = get_config('block_configurable_reports', 'reportlimit');
+        if (empty($reportlimit) || $reportlimit === '0') {
+            $reportlimit = BLOCK_CONFIGURABLE_REPORTS_MAX_RECORDS;
+        }
+
+        $starttime = microtime(true);
+        $results = $remotedb->get_recordset_sql($sql, $this->queryparams, 0, $reportlimit);
+
+        $updaterecord = $DB->get_record('block_configurable_reports', ['id' => $this->config->id]);
+        $updaterecord->lastexecutiontime = round((microtime(true) - $starttime) * 1000);
+        $this->config->lastexecutiontime = $updaterecord->lastexecutiontime;
+        $DB->update_record('block_configurable_reports', $updaterecord);
+
+        return $results;
+    }
+}

--- a/classes/local/dynamic_report.php
+++ b/classes/local/dynamic_report.php
@@ -47,7 +47,7 @@ final class dynamic_report extends \report_sql {
 
         $sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
         $reportlimit = get_config('block_configurable_reports', 'reportlimit');
-        if (empty($reportlimit) || $reportlimit === '0') {
+        if (empty($reportlimit)) {
             $reportlimit = BLOCK_CONFIGURABLE_REPORTS_MAX_RECORDS;
         }
 

--- a/classes/local/dynamic_sql.php
+++ b/classes/local/dynamic_sql.php
@@ -1,0 +1,179 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_configurable_reports\local;
+
+use invalid_parameter_exception;
+use moodle_exception;
+
+/**
+ * Expands dynamic placeholders in Configurable Reports SQL.
+ *
+ * @package    block_configurable_reports
+ * @copyright  2026 Frank Saikali <fsjk85@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class dynamic_sql {
+    /** @var string Regular expression matching supported dynamic placeholders. */
+    private const PLACEHOLDER_PATTERN =
+        '/%%DYNAMIC_([A-Z0-9_]+):([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)?)(?::(<=|>=|=|<|>|~|in))?%%/i';
+
+    /** @var string Regular expression matching any remaining dynamic placeholder. */
+    private const UNRESOLVED_PLACEHOLDER_PATTERN = '/%%DYNAMIC_[^%]+%%/i';
+
+    /**
+     * Extracts the supported dynamic placeholders from a SQL query.
+     *
+     * @param string $sql SQL query.
+     * @return array
+     */
+    public static function extract_parameters(string $sql): array {
+        preg_match_all(self::PLACEHOLDER_PATTERN, $sql, $matches, PREG_SET_ORDER);
+
+        $parameters = [];
+        foreach ($matches as $match) {
+            $name = strtoupper($match[1]);
+            $parameters[$name] = [
+                'name' => $name,
+                'field' => $match[2],
+                'operator' => $match[3] ?? '~',
+                'placeholder' => $match[0],
+                'required' => false,
+            ];
+        }
+
+        return array_values($parameters);
+    }
+
+    /**
+     * Replaces supported dynamic placeholders with submitted values.
+     *
+     * @param string $sql SQL query.
+     * @param array $parameters Submitted parameters.
+     * @return array SQL query and DML parameters.
+     */
+    public static function apply_parameters(string $sql, array $parameters): array {
+        global $remotedb;
+
+        $parammap = self::normalise_parameters($parameters);
+        $queryparams = [];
+        $paramindex = 0;
+
+        $sql = preg_replace_callback(
+            self::PLACEHOLDER_PATTERN,
+            static function(array $matches) use ($parammap, &$queryparams, &$paramindex, $remotedb): string {
+                $name = strtoupper($matches[1]);
+                if (!array_key_exists($name, $parammap) || $parammap[$name] === '') {
+                    return '';
+                }
+
+                return self::get_sql_condition(
+                    $matches[2],
+                    $matches[3] ?? '~',
+                    $parammap[$name],
+                    $queryparams,
+                    $paramindex,
+                    $remotedb
+                );
+            },
+            $sql
+        );
+
+        if (preg_match(self::UNRESOLVED_PLACEHOLDER_PATTERN, $sql)) {
+            throw new moodle_exception('unresolvedplaceholder', 'block_configurable_reports');
+        }
+
+        return [$sql, $queryparams];
+    }
+
+    /**
+     * Returns a SQL condition for one dynamic parameter.
+     *
+     * @param string $field SQL field.
+     * @param string $operator SQL operator.
+     * @param mixed $value Submitted value.
+     * @param array $queryparams DML query parameters.
+     * @param int $paramindex Next DML parameter index.
+     * @param \moodle_database $database Database connection used to run the query.
+     * @return string
+     */
+    private static function get_sql_condition(
+        string $field,
+        string $operator,
+        $value,
+        array &$queryparams,
+        int &$paramindex,
+        \moodle_database $database
+    ): string {
+        if ($operator === '~') {
+            $placeholder = self::add_query_parameter(
+                "%{$database->sql_like_escape(trim((string) $value))}%",
+                $queryparams,
+                $paramindex
+            );
+            return ' AND ' . $database->sql_like($field, $placeholder, false);
+        }
+
+        if ($operator === 'in') {
+            $conditions = [];
+            foreach (preg_split('/(?<!\\\\),/', (string) $value) as $item) {
+                $item = str_replace('\\,', ',', trim(trim($item), '"\''));
+                if ($item !== '') {
+                    $conditions[] = "{$field} = " . self::add_query_parameter($item, $queryparams, $paramindex);
+                }
+            }
+
+            return empty($conditions) ? '' : ' AND (' . implode(' OR ', $conditions) . ')';
+        }
+
+        return " AND {$field} {$operator} " . self::add_query_parameter(trim((string) $value), $queryparams, $paramindex);
+    }
+
+    /**
+     * Adds a submitted value to the DML query parameters.
+     *
+     * @param string $value Submitted value.
+     * @param array $queryparams DML query parameters.
+     * @param int $paramindex Next DML parameter index.
+     * @return string
+     */
+    private static function add_query_parameter(string $value, array &$queryparams, int &$paramindex): string {
+        $name = 'blockdynamic' . $paramindex++;
+        $queryparams[$name] = $value;
+
+        return ':' . $name;
+    }
+
+    /**
+     * Normalises submitted parameters into a name-to-value map.
+     *
+     * @param array $parameters Submitted parameters.
+     * @return array
+     */
+    private static function normalise_parameters(array $parameters): array {
+        $map = [];
+        foreach ($parameters as $parameter) {
+            $name = strtoupper(trim($parameter['name']));
+            if (!preg_match('/^[A-Z0-9_]+$/', $name)) {
+                throw new invalid_parameter_exception('Invalid dynamic parameter name: ' . $name);
+            }
+
+            $map[$name] = $parameter['value'];
+        }
+
+        return $map;
+    }
+}

--- a/classes/local/dynamic_sql.php
+++ b/classes/local/dynamic_sql.php
@@ -29,7 +29,7 @@ use moodle_exception;
 final class dynamic_sql {
     /** @var string Regular expression matching supported dynamic placeholders. */
     private const PLACEHOLDER_PATTERN =
-        '/%%DYNAMIC_([A-Z0-9_]+):([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)?)(?::(<=|>=|=|<|>|~|in))?%%/i';
+        '/%%DYNAMIC_([A-Z0-9_-]+):([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)?)(?::(<=|>=|=|<|>|~|in))?%%/i';
 
     /** @var string Regular expression matching any remaining dynamic placeholder. */
     private const UNRESOLVED_PLACEHOLDER_PATTERN = '/%%DYNAMIC_[^%]+%%/i';
@@ -41,7 +41,7 @@ final class dynamic_sql {
      * @return array
      */
     public static function extract_parameters(string $sql): array {
-        preg_match_all(self::PLACEHOLDER_PATTERN, $sql, $matches, PREG_SET_ORDER);
+        $matches = self::get_placeholder_matches($sql);
 
         $parameters = [];
         foreach ($matches as $match) {
@@ -68,13 +68,14 @@ final class dynamic_sql {
     public static function apply_parameters(string $sql, array $parameters): array {
         global $remotedb;
 
+        self::get_placeholder_matches($sql);
         $parammap = self::normalise_parameters($parameters);
         $queryparams = [];
         $paramindex = 0;
 
         $sql = preg_replace_callback(
             self::PLACEHOLDER_PATTERN,
-            static function(array $matches) use ($parammap, &$queryparams, &$paramindex, $remotedb): string {
+            static function (array $matches) use ($parammap, &$queryparams, &$paramindex, $remotedb): string {
                 $name = strtoupper($matches[1]);
                 if (!array_key_exists($name, $parammap) || $parammap[$name] === '') {
                     return '';
@@ -128,15 +129,23 @@ final class dynamic_sql {
         }
 
         if ($operator === 'in') {
-            $conditions = [];
+            $items = [];
             foreach (preg_split('/(?<!\\\\),/', (string) $value) as $item) {
                 $item = str_replace('\\,', ',', trim(trim($item), '"\''));
                 if ($item !== '') {
-                    $conditions[] = "{$field} = " . self::add_query_parameter($item, $queryparams, $paramindex);
+                    $items[] = $item;
                 }
             }
 
-            return empty($conditions) ? '' : ' AND (' . implode(' OR ', $conditions) . ')';
+            if (empty($items)) {
+                return '';
+            }
+
+            $prefix = 'blockdynamicin' . $paramindex++;
+            [$insql, $inparams] = $database->get_in_or_equal($items, SQL_PARAMS_NAMED, $prefix);
+            $queryparams += $inparams;
+
+            return " AND {$field} {$insql}";
         }
 
         return " AND {$field} {$operator} " . self::add_query_parameter(trim((string) $value), $queryparams, $paramindex);
@@ -167,13 +176,38 @@ final class dynamic_sql {
         $map = [];
         foreach ($parameters as $parameter) {
             $name = strtoupper(trim($parameter['name']));
-            if (!preg_match('/^[A-Z0-9_]+$/', $name)) {
+            if (!preg_match('/^[A-Z0-9_-]+$/', $name)) {
                 throw new invalid_parameter_exception('Invalid dynamic parameter name: ' . $name);
+            }
+            if (array_key_exists($name, $map)) {
+                throw new invalid_parameter_exception('Duplicate dynamic parameter name: ' . $name);
             }
 
             $map[$name] = $parameter['value'];
         }
 
         return $map;
+    }
+
+    /**
+     * Returns supported dynamic placeholders after validating their names are unique.
+     *
+     * @param string $sql SQL query.
+     * @return array
+     */
+    private static function get_placeholder_matches(string $sql): array {
+        preg_match_all(self::PLACEHOLDER_PATTERN, $sql, $matches, PREG_SET_ORDER);
+
+        $names = [];
+        foreach ($matches as $match) {
+            $name = strtoupper($match[1]);
+            if (array_key_exists($name, $names)) {
+                throw new moodle_exception('duplicatedynamicparameter', 'block_configurable_reports');
+            }
+
+            $names[$name] = true;
+        }
+
+        return $matches;
     }
 }

--- a/classes/local/dynamic_sql.php
+++ b/classes/local/dynamic_sql.php
@@ -49,7 +49,7 @@ final class dynamic_sql {
             $parameters[$name] = [
                 'name' => $name,
                 'field' => $match[2],
-                'operator' => $match[3] ?? '~',
+                'operator' => strtolower($match[3] ?? '~'),
                 'placeholder' => $match[0],
                 'required' => false,
             ];
@@ -64,6 +64,8 @@ final class dynamic_sql {
      * @param string $sql SQL query.
      * @param array $parameters Submitted parameters.
      * @return array SQL query and DML parameters.
+     * @throws invalid_parameter_exception If a submitted parameter is invalid or duplicated.
+     * @throws moodle_exception If the SQL contains unresolved dynamic placeholders.
      */
     public static function apply_parameters(string $sql, array $parameters): array {
         global $remotedb;
@@ -83,7 +85,7 @@ final class dynamic_sql {
 
                 return self::get_sql_condition(
                     $matches[2],
-                    $matches[3] ?? '~',
+                    strtolower($matches[3] ?? '~'),
                     $parammap[$name],
                     $queryparams,
                     $paramindex,
@@ -171,6 +173,7 @@ final class dynamic_sql {
      *
      * @param array $parameters Submitted parameters.
      * @return array
+     * @throws invalid_parameter_exception If a submitted parameter is invalid or duplicated.
      */
     private static function normalise_parameters(array $parameters): array {
         $map = [];
@@ -194,6 +197,7 @@ final class dynamic_sql {
      *
      * @param string $sql SQL query.
      * @return array
+     * @throws moodle_exception If the SQL contains duplicate dynamic placeholder names.
      */
     private static function get_placeholder_matches(string $sql): array {
         preg_match_all(self::PLACEHOLDER_PATTERN, $sql, $matches, PREG_SET_ORDER);

--- a/components/customsql/form.php
+++ b/components/customsql/form.php
@@ -129,6 +129,11 @@ class customsql_form extends moodleform {
         $sql = $data['querysql'];
         $sql = trim($sql);
 
+        if (!$this->validate_dynamic_parameters($sql)) {
+            $errors['querysql'] = get_string('duplicatedynamicparameter', 'block_configurable_reports');
+            return $errors;
+        }
+
         // Simple test to avoid evil stuff in the SQL.
         $regex = '/\b(ALTER|CREATE|DELETE|DROP|GRANT|INSERT|INTO|TRUNCATE|UPDATE|SET|VACUUM|REINDEX|DISCARD|LOCK)\b/i';
         if (preg_match($regex, $sql)) {
@@ -179,6 +184,11 @@ class customsql_form extends moodleform {
         $sql = $data['querysql'];
         $sql = trim($sql);
 
+        if (!$this->validate_dynamic_parameters($sql)) {
+            $errors['querysql'] = get_string('duplicatedynamicparameter', 'block_configurable_reports');
+            return $errors;
+        }
+
         if (preg_match('/\b(ALTER|DELETE|DROP|GRANT|TRUNCATE|UPDATE|SET|VACUUM|REINDEX|DISCARD|LOCK)\b/i', $sql)) {
             // Only allow INSERT|INTO|CREATE in low security.
             $errors['querysql'] = get_string('notallowedwords', 'block_configurable_reports');
@@ -206,5 +216,21 @@ class customsql_form extends moodleform {
         }
 
         return $errors;
+    }
+
+    /**
+     * Validates dynamic SQL placeholder names.
+     *
+     * @param string $sql SQL query.
+     * @return bool
+     */
+    private function validate_dynamic_parameters(string $sql): bool {
+        try {
+            \block_configurable_reports\local\dynamic_sql::extract_parameters($sql);
+        } catch (moodle_exception $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/db/services.php
+++ b/db/services.php
@@ -38,6 +38,7 @@ $functions = [
         'classname' => 'block_configurable_reports\external',
         'methodname' => 'get_reports',
         'description' => 'Returns available reports and their dynamic parameters.',
+        'capabilities' => 'block/configurable_reports:viewreports',
         'type' => 'read',
         'ajax' => true,
     ],

--- a/db/services.php
+++ b/db/services.php
@@ -29,7 +29,15 @@ $functions = [
     'block_configurable_reports_get_report_data' => [
         'classname' => 'block_configurable_reports\external',
         'methodname' => 'get_report_data',
-        'description' => 'Return data as JSON for given report ID.',
+        'description' => 'Return data as JSON for given report ID, optionally applying dynamic SQL parameters.',
+        'type' => 'read',
+        'ajax' => true,
+    ],
+
+    'block_configurable_reports_get_dynamic_reports' => [
+        'classname' => 'block_configurable_reports\external',
+        'methodname' => 'get_dynamic_reports',
+        'description' => 'Returns available SQL reports and their dynamic parameters.',
         'type' => 'read',
         'ajax' => true,
     ],

--- a/db/services.php
+++ b/db/services.php
@@ -34,10 +34,10 @@ $functions = [
         'ajax' => true,
     ],
 
-    'block_configurable_reports_get_dynamic_reports' => [
+    'block_configurable_reports_get_reports' => [
         'classname' => 'block_configurable_reports\external',
-        'methodname' => 'get_dynamic_reports',
-        'description' => 'Returns available SQL reports and their dynamic parameters.',
+        'methodname' => 'get_reports',
+        'description' => 'Returns available reports and their dynamic parameters.',
         'type' => 'read',
         'ajax' => true,
     ],

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -589,6 +589,8 @@ arbitrary code. SQL code execution should be disable to only allow SQL queries f
 be disabled in your config.php file by setting $CFG->block_configurable_reports_enable_sql_execution to 0';
 $string['csvdelimiter'] = 'CSV delimiter';
 $string['csvdelimiterinfo'] = 'CSV delimiter: "colon" for ":", "comma" for ",", semicolon for ";",  "tab" for "\t" and "cfg" for character configured in "CFG->CSV_DELIMITER" of the config.php file.';
+$string['duplicatedynamicparameter'] = 'A dynamic parameter name can only be used once per report.';
+$string['invaliddynamicparameters'] = 'The report has invalid dynamic SQL parameters.';
 $string['missingcustomsql'] = 'The report does not contain custom SQL.';
 $string['missingreportclass'] = 'The Configurable Reports report class was not found.';
 $string['missingreportclassfile'] = 'The Configurable Reports report class file was not found.';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -589,3 +589,7 @@ arbitrary code. SQL code execution should be disable to only allow SQL queries f
 be disabled in your config.php file by setting $CFG->block_configurable_reports_enable_sql_execution to 0';
 $string['csvdelimiter'] = 'CSV delimiter';
 $string['csvdelimiterinfo'] = 'CSV delimiter: "colon" for ":", "comma" for ",", semicolon for ";",  "tab" for "\t" and "cfg" for character configured in "CFG->CSV_DELIMITER" of the config.php file.';
+$string['missingcustomsql'] = 'The report does not contain custom SQL.';
+$string['missingreportclass'] = 'The Configurable Reports report class was not found.';
+$string['missingreportclassfile'] = 'The Configurable Reports report class file was not found.';
+$string['unresolvedplaceholder'] = 'An unresolved dynamic placeholder remains in the report SQL.';

--- a/tests/local/dynamic_sql_test.php
+++ b/tests/local/dynamic_sql_test.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_configurable_reports\local;
+
+use moodle_exception;
+
+/**
+ * Tests for dynamic SQL placeholder expansion.
+ *
+ * @package    block_configurable_reports
+ * @copyright  2026 Monash University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \block_configurable_reports\local\dynamic_sql
+ */
+final class dynamic_sql_test extends \advanced_testcase {
+    /**
+     * Tests the extraction of supported placeholder metadata.
+     */
+    public function test_extract_parameters(): void {
+        $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
+            . '%%DYNAMIC_USER:u.id:=%% %%DYNAMIC_NAME:u.username:~%%';
+
+        $this->assertSame([
+            [
+                'name' => 'USER',
+                'field' => 'u.id',
+                'operator' => '=',
+                'placeholder' => '%%DYNAMIC_USER:u.id:=%%',
+                'required' => false,
+            ],
+            [
+                'name' => 'NAME',
+                'field' => 'u.username',
+                'operator' => '~',
+                'placeholder' => '%%DYNAMIC_NAME:u.username:~%%',
+                'required' => false,
+            ],
+        ], dynamic_sql::extract_parameters($sql));
+    }
+
+    /**
+     * Tests replacement and quoting of submitted values.
+     */
+    public function test_apply_parameters(): void {
+        global $DB, $remotedb;
+
+        $remotedb = $DB;
+
+        $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
+            . '%%DYNAMIC_USER:u.id:=%% %%DYNAMIC_NAME:u.username:=%% %%DYNAMIC_UNUSED:u.deleted:=%%';
+
+        [$actual, $params] = dynamic_sql::apply_parameters($sql, [
+            ['name' => 'USER', 'value' => '42'],
+            ['name' => 'NAME', 'value' => "O'Brien"],
+        ]);
+
+        $this->assertStringContainsString(' AND u.id = :blockdynamic0', $actual);
+        $this->assertStringContainsString(' AND u.username = :blockdynamic1', $actual);
+        $this->assertStringNotContainsString('DYNAMIC_UNUSED', $actual);
+        $this->assertSame(['blockdynamic0' => '42', 'blockdynamic1' => "O'Brien"], $params);
+    }
+
+    /**
+     * Tests that IN placeholders use distinct query parameter names.
+     */
+    public function test_apply_parameters_with_multiple_in_conditions(): void {
+        global $DB, $remotedb;
+
+        $remotedb = $DB;
+        $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
+            . '%%DYNAMIC_IDS:u.id:in%% %%DYNAMIC_DELETED:u.deleted:in%%';
+
+        [$actual, $params] = dynamic_sql::apply_parameters($sql, [
+            ['name' => 'IDS', 'value' => '1,2'],
+            ['name' => 'DELETED', 'value' => '0,1'],
+        ]);
+
+        $this->assertStringContainsString(' AND u.id IN (', $actual);
+        $this->assertStringContainsString(' AND u.deleted IN (', $actual);
+        preg_match_all('/:(blockdynamicin\d+)/', $actual, $matches);
+        $this->assertSame(array_keys($params), $matches[1]);
+        $this->assertSame(['1', '2', '0', '1'], array_values($params));
+    }
+
+    /**
+     * Tests rejection of malformed placeholders.
+     */
+    public function test_apply_parameters_rejects_malformed_placeholder(): void {
+        global $DB, $remotedb;
+
+        $remotedb = $DB;
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('unresolvedplaceholder', 'block_configurable_reports'));
+
+        dynamic_sql::apply_parameters('SELECT 1 %%DYNAMIC_BAD:u.id:drop%%', []);
+    }
+
+    /**
+     * Tests rejection of duplicate placeholder names.
+     */
+    public function test_extract_parameters_rejects_duplicate_names(): void {
+        $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
+            . '%%DYNAMIC_SEARCH:u.firstname:~%% %%DYNAMIC_SEARCH:u.lastname:~%%';
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('duplicatedynamicparameter', 'block_configurable_reports'));
+
+        dynamic_sql::extract_parameters($sql);
+    }
+}

--- a/tests/local/dynamic_sql_test.php
+++ b/tests/local/dynamic_sql_test.php
@@ -28,6 +28,16 @@ use moodle_exception;
  */
 final class dynamic_sql_test extends \advanced_testcase {
     /**
+     * Sets the database used to expand dynamic SQL parameters.
+     */
+    protected function setUp(): void {
+        global $DB, $remotedb;
+
+        parent::setUp();
+        $remotedb = $DB;
+    }
+
+    /**
      * Tests the extraction of supported placeholder metadata.
      */
     public function test_extract_parameters(): void {
@@ -56,10 +66,6 @@ final class dynamic_sql_test extends \advanced_testcase {
      * Tests replacement and quoting of submitted values.
      */
     public function test_apply_parameters(): void {
-        global $DB, $remotedb;
-
-        $remotedb = $DB;
-
         $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
             . '%%DYNAMIC_USER:u.id:=%% %%DYNAMIC_NAME:u.username:=%% %%DYNAMIC_UNUSED:u.deleted:=%%';
 
@@ -78,11 +84,8 @@ final class dynamic_sql_test extends \advanced_testcase {
      * Tests that IN placeholders use distinct query parameter names.
      */
     public function test_apply_parameters_with_multiple_in_conditions(): void {
-        global $DB, $remotedb;
-
-        $remotedb = $DB;
         $sql = 'SELECT * FROM prefix_user u WHERE 1 = 1 '
-            . '%%DYNAMIC_IDS:u.id:in%% %%DYNAMIC_DELETED:u.deleted:in%%';
+            . '%%DYNAMIC_IDS:u.id:in%% %%DYNAMIC_DELETED:u.deleted:IN%%';
 
         [$actual, $params] = dynamic_sql::apply_parameters($sql, [
             ['name' => 'IDS', 'value' => '1,2'],
@@ -100,9 +103,6 @@ final class dynamic_sql_test extends \advanced_testcase {
      * Tests rejection of malformed placeholders.
      */
     public function test_apply_parameters_rejects_malformed_placeholder(): void {
-        global $DB, $remotedb;
-
-        $remotedb = $DB;
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage(get_string('unresolvedplaceholder', 'block_configurable_reports'));
 

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024051301;
+$plugin->version = 2026061000;
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0';

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026061000;
+$plugin->version = 2026062300;
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0';


### PR DESCRIPTION
## Summary

Adds dynamic SQL support to Configurable Reports web services.

## Changes

- Adds `block_configurable_reports_get_dynamic_reports` to list SQL reports and their dynamic parameters.
- Updates `block_configurable_reports_get_report_data` to accept optional dynamic parameter values.
- Executes dynamic SQL using bound Moodle DML parameters.

## How To Use

Example SQL report:

```sql
SELECT u.id, u.username, u.firstname, u.lastname, u.email
FROM prefix_user u
WHERE u.deleted = 0
%%DYNAMIC_USERNAME:u.username:~%%

Call block_configurable_reports_get_dynamic_reports with courseid(optionally) to find reports and dynamic parameters.

Call block_configurable_reports_get_report_data with:
{
  "reportid": 123,
  "courseid": 1,
  "parameters": [
    {
      "name": "USERNAME",
      "value": "smith"
    }
  ]
}

This applies a dynamic LIKE filter to u.username.